### PR TITLE
use the device id to create a unique ble identifier

### DIFF
--- a/ble/ble.c
+++ b/ble/ble.c
@@ -37,7 +37,7 @@
 #define CENTRAL_LINK_COUNT              0                                           /**< Number of central links used by the application. When changing this number remember to adjust the RAM settings*/
 #define PERIPHERAL_LINK_COUNT           1                                           /**< Number of peripheral links used by the application. When changing this number remember to adjust the RAM settings*/
 
-#define DEVICE_NAME                     "SMAQ2"                                     /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME                     "SMAQ2"                                     /**< Name of device. Will be included in the advertising data. Device ID will be appended.*/
 #define DEVICE_NAME_MAX_SIZE            15                                          /**< Maximum length for device name - limited by softdevice. */
 #define NUS_SERVICE_UUID_TYPE           BLE_UUID_TYPE_VENDOR_BEGIN                  /**< UUID type for the Nordic UART Service (vendor specific). */
 


### PR DESCRIPTION
currently this creates an exception on bootup, i assume the device id is to long. when only using one byte as suffix, it works.

Any ideas?

This change requires a new build of GB as described here: https://github.com/Emeryth/Gadgetbridge/pull/2 or included in the [upstream PR](https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/2215).